### PR TITLE
Add support for Slurm scheduler

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,15 @@ Changes
 =======
 
 
+0.7.0
+-----
+
+New features
+^^^^^^^^^^^^
+
+* Added support for the Slurm Workload Manager.
+
+
 0.6.0
 -----
 

--- a/doc/source/guide.rst
+++ b/doc/source/guide.rst
@@ -372,9 +372,41 @@ Schedulers
 
 Schedulers define how Psyrun submits individual jobs. The default is
 `ImmediateRun` which is not really a scheduler because it just immediately runs
-any job on submission. Psyrun comes with support for Sharcnet's ``sqsub`` with
-the `Sqsub` scheduler. For other schedulers it is necessary
-to write some custom code.
+any job on submission. Psyrun comes with support for
+`Slurm Workload Manager <https://slurm.schedmd.com/>`_ (used by `Compute Canada
+<http://computecanada.ca/>`_'s new clusters and Sharcnet's ``sqsub`` scheduler.
+For other schedulers it is necessary to write some custom code.
+
+
+Slurm scheduler (e.g., Compute Canada)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The `Slurm` scheduler uses ``sbatch`` to submit jobs. It accepts the following
+*scheduler_args* (corresponding ``sbatch`` command line options are given in
+parenthesis):
+
+* *timelimit* (``-t``): String stating the execution time limit for
+  each individual job.
+* *memory* (``--mem``): String stating the memory limit per node.
+* *memory_per_cpu* (``--mem-per-cpu``): String stating the minimum memory
+  required per CPU.
+* *n_cpus* (``-c``): Number of CPU cores to allocate for each task.
+* *n_nodes* (``-N``): Number of nodes to allocate for each individual
+  job.
+* *cores-per-socket* (``--cores-per-socket``): Minimum number of cores per
+  socket.
+* *sockets-per-node* (``--sockets-per-node``): Minimum number of sockets per
+  node.
+
+For more details see `the sbatch help <https://slurm.schedmd.com/sbatch.html>`_.
+Not all options that can be passed to ``sbatch`` are currently supported.
+Please `open a new issue <https://github.com/jgosmann/psyrun/issues/new>`_ if
+you require support for further options.
+
+Instead of a fixed value, you can also assign a function accepting the job
+name as single argument to `Slurm` scheduler arguments. The function will be
+called with the job name to determine the value of the argument.
+
 
 Sqsub scheduler (Sharcnet)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/psyrun/backend/base.py
+++ b/psyrun/backend/base.py
@@ -175,7 +175,7 @@ class Backend(object):
 
         self._prepare_job_submission(job_source_file, name)
 
-        output_filename = os.path.join(self.workdir, name + '.log')
+        output_filename = os.path.join(self.workdir, name + ':%a.log')
         return self.task.scheduler.submit_array(
             n, [job_source_file.path] + args, output_filename,
             name, depends_on, self.task.scheduler_args)

--- a/psyrun/backend/base.py
+++ b/psyrun/backend/base.py
@@ -1,6 +1,7 @@
 """Base backend interface."""
 
 import os
+import stat
 import sys
 
 
@@ -35,6 +36,8 @@ class JobSourceFile(object):
         """Write the job code to the file *self.path*."""
         with open(self.path, 'w') as f:
             f.write(self.full_code)
+            fd = f.fileno()
+            os.fchmod(fd, os.fstat(fd).st_mode | stat.S_IXUSR)
         self.written = True
 
     @property
@@ -149,7 +152,7 @@ class Backend(object):
                 self.task.scheduler.kill(job)
 
         return self.task.scheduler.submit(
-            [self.task.python, job_source_file.path] + args, output_filename,
+            [job_source_file.path] + args, output_filename,
             name, depends_on, self.task.scheduler_args)
 
     def create_job(self, cont=False):

--- a/psyrun/backend/base.py
+++ b/psyrun/backend/base.py
@@ -142,7 +142,45 @@ class Backend(object):
         if args is None:
             args = []
 
+        self._prepare_job_submission(job_source_file, name)
+
         output_filename = os.path.join(self.workdir, name + '.log')
+        return self.task.scheduler.submit(
+            [job_source_file.path] + args, output_filename,
+            name, depends_on, self.task.scheduler_args)
+
+    def submit_array(
+            self, n, job_source_file, name, depends_on=None, args=None):
+        """Submits a source file to execute to the task scheduler.
+
+        Parameters
+        ----------
+        job_source_file : `JobSourceFile`
+            Source file to execute in job.
+        name: str
+            Job name.
+        depends_on: sequence
+            Job IDs that have to finish before the submitted code can be
+            executed.
+        args : sequence
+            Additional arguments to pass to the job.
+
+        Returns
+        -------
+        dict
+            Contains the id of the submitted job under the key ``'id'``.
+        """
+        if args is None:
+            args = []
+
+        self._prepare_job_submission(job_source_file, name)
+
+        output_filename = os.path.join(self.workdir, name + '.log')
+        return self.task.scheduler.submit_array(
+            n, [job_source_file.path] + args, output_filename,
+            name, depends_on, self.task.scheduler_args)
+
+    def _prepare_job_submission(self, job_source_file, name):
         if not job_source_file.written:
             job_source_file.write()
 
@@ -150,10 +188,6 @@ class Backend(object):
             status = self.task.scheduler.get_status(job)
             if status is not None and name == status.name:
                 self.task.scheduler.kill(job)
-
-        return self.task.scheduler.submit(
-            [job_source_file.path] + args, output_filename,
-            name, depends_on, self.task.scheduler_args)
 
     def create_job(self, cont=False):
         """Create the job tree to process given task.

--- a/psyrun/backend/base.py
+++ b/psyrun/backend/base.py
@@ -39,7 +39,7 @@ class JobSourceFile(object):
 
     @property
     def full_code(self):
-        return '''
+        return '''#!{python}
 try:
     import faulthandler
     faulthandler.enable()
@@ -59,6 +59,7 @@ from psyrun.tasks import TaskDef
 task = TaskDef({taskpath!r})
 {code}
         '''.format(
+            python=self.task.python,
             path=sys.path,
             taskdir=os.path.abspath(os.path.dirname(self.task.path)),
             taskpath=os.path.abspath(self.task.path), code=self.job_code)

--- a/psyrun/backend/distribute.py
+++ b/psyrun/backend/distribute.py
@@ -105,9 +105,14 @@ Splitter(
             '''
 import sys
 from psyrun.backend.distribute import Worker
-execute = task.execute
-Worker(store=task.store).start(execute, sys.argv[1], sys.argv[2])
-            ''')
+
+def execute(*args, **kwargs):
+    return task.execute(*args, **kwargs)
+
+if __name__ == '__main__':
+    Worker(store=task.store).start(execute, sys.argv[1], sys.argv[2],
+           pool_size={pool_size})
+            '''.format(pool_size=self.task.pool_size))
 
         infile = os.path.join(splitter.indir, '%a' + splitter.store.ext)
         outfile = os.path.join(splitter.outdir, '%a' + splitter.store.ext)
@@ -331,7 +336,7 @@ class Worker(object):
     def __init__(self, store=DefaultStore()):
         self.store = store
 
-    def start(self, fn, infile, outfile):
+    def start(self, fn, infile, outfile, pool_size=1):
         """Start processing a parameter space.
 
         Parameters
@@ -347,5 +352,5 @@ class Worker(object):
         out_root, out_ext = os.path.splitext(outfile)
         map_pspace_hdd_backed(
             fn, pspace, out_root + '.part' + out_ext, store=self.store,
-            return_data=False)
+            return_data=False, pool_size=pool_size)
         os.rename(out_root + '.part' + out_ext, outfile)

--- a/psyrun/backend/distribute.py
+++ b/psyrun/backend/distribute.py
@@ -112,7 +112,7 @@ Worker(store=task.store).start(execute, sys.argv[1], sys.argv[2])
         infile = os.path.join(splitter.indir, '%a' + splitter.store.ext)
         outfile = os.path.join(splitter.outdir, '%a' + splitter.store.ext)
         return JobArray(
-            splitter.n_splits, 'process', self.submit_file,
+            splitter.n_splits, 'process', self.submit_array, self.submit_file,
             {'job_source_file': source_file, 'args': [infile, outfile]},
             [infile], [outfile])
 

--- a/psyrun/backend/load_balancing.py
+++ b/psyrun/backend/load_balancing.py
@@ -4,7 +4,7 @@ import fcntl
 import os
 
 from psyrun.backend.base import Backend, JobSourceFile
-from psyrun.jobs import Job, JobChain, JobGroup
+from psyrun.jobs import Job, JobArray, JobChain
 from psyrun.mapper import map_pspace
 from psyrun.pspace import missing, Param
 from psyrun.store import DefaultStore
@@ -92,18 +92,11 @@ LoadBalancingWorker(sys.argv[1], sys.argv[2], sys.argv[3], task.store).start(
     task.execute)
             ''')
 
-        jobs = []
-        for i in range(self.task.max_jobs):
-            jobs.append(Job(
-                str(i), self.submit_file,
-                {'job_source_file': source_file, 'args': [
-                    self.infile,
-                    self.partial_resultfile,
-                    self.statusfile
-                ]}, [self.infile], [self.partial_resultfile]))
-
-        group = JobGroup('process', jobs)
-        return group
+        return JobArray(
+            self.task.max_jobs, 'process', self.submit_array, self.submit_file,
+            {'job_source_file': source_file, 'args': [
+                self.infile, self.partial_resultfile, self.statusfile
+            ]}, [self.infile], [self.partial_resultfile])
 
     def create_finalize_job(self):
         code = '''

--- a/psyrun/scheduler.py
+++ b/psyrun/scheduler.py
@@ -188,6 +188,10 @@ class ExternalScheduler(Scheduler):
         def build(self, value):
             raise NotImplementedError()
 
+        def __repr__(self):
+            return "<{clsname} '{name}'>".format(
+                clsname=self.__class__.__name__, name=self.name)
+
     class ShortOption(Option):
         def build(self, value):
             if value is None:

--- a/psyrun/scheduler.py
+++ b/psyrun/scheduler.py
@@ -554,23 +554,24 @@ sys.exit(subprocess.call([a.replace('%a', str(task_id)) for a in {args!r}]))
             self.refresh_job_info()
         elif jobid not in self._jobs:
             stdout = subprocess.check_output(
-                ['squeue', '-u', getpass.getuser(), '-h', '-o', '%A %t %j',
+                ['squeue', '-u', getpass.getuser(), '-h', '-o', '%A %t %j %r',
                  '-j', str(jobid)],
                 stderr=subprocess.STDOUT, universal_newlines=True)
             for line in stdout.split('\n'):
-                cols = line.split(None, 3)
-                if len(cols) > 2 and cols[1] in ['PD', 'R', 'CF', 'CG']:
+                cols = line.split(None, 4)
+                if len(cols) > 3 and cols[1] in ['PD', 'R', 'CF', 'CG']:
                     jobid = cols[0]
+                    status = self.STATUS_MAP[cols[1]]
+                    if status == 'Q' and cols[3] == 'Dependency':
+                        status = '*Q'
                     m = re.match(r'^(\d+)_\[(\d+)-(\d+)\]$', jobid)
                     if m:
                         for i in range(int(m.group(2)), int(m.group(3)) + 1):
                             sub_id = m.group(1) + '_' + str(i)
                             self._jobs[sub_id] = JobStatus(
-                                sub_id, self.STATUS_MAP[cols[1]],
-                                cols[-1] + ':' + str(i))
+                                sub_id, status, cols[-1] + ':' + str(i))
                     else:
-                        self._jobs[jobid] = JobStatus(
-                            jobid, self.STATUS_MAP[cols[1]], cols[-1])
+                        self._jobs[jobid] = JobStatus(jobid, status, cols[-1])
         return self._jobs.get(jobid, None)
 
     def get_jobs(self):
@@ -588,19 +589,20 @@ sys.exit(subprocess.call([a.replace('%a', str(task_id)) for a in {args!r}]))
     def refresh_job_info(self):
         self._jobs = {}
         stdout = subprocess.check_output(
-            ['squeue', '-u', getpass.getuser(), '-h', '-o', '%i %t %j'],
+            ['squeue', '-u', getpass.getuser(), '-h', '-o', '%i %t %j %r'],
             universal_newlines=True)
         for line in stdout.split('\n'):
             cols = line.split(None, 3)
-            if len(cols) > 2 and cols[1] in ['PD', 'R', 'CF', 'CG']:
+            if len(cols) > 3 and cols[1] in ['PD', 'R', 'CF', 'CG']:
                 jobid = cols[0]
+                status = self.STATUS_MAP[cols[1]]
+                if status == 'Q' and cols[3] == 'Dependency':
+                    status = '*Q'
                 m = re.match(r'^(\d+)_\[(\d+)-(\d+)\]$', jobid)
                 if m:
                     for i in range(int(m.group(2)), int(m.group(3)) + 1):
                         sub_id = m.group(1) + '_' + str(i)
                         self._jobs[sub_id] = JobStatus(
-                            sub_id, self.STATUS_MAP[cols[1]],
-                            cols[-1] + ':' + str(i))
+                            sub_id, status, cols[-1] + ':' + str(i))
                 else:
-                    self._jobs[jobid] = JobStatus(
-                        jobid, self.STATUS_MAP[cols[1]], cols[-1])
+                    self._jobs[jobid] = JobStatus(jobid, status, cols[-1])

--- a/psyrun/scheduler.py
+++ b/psyrun/scheduler.py
@@ -460,6 +460,7 @@ class Slurm(Scheduler):
         """
         out = subprocess.check_output(self._prepare_submisson_cmd(
             args, output_filename, name, scheduler_args, depends_on))
+        out = out.decode('utf-8')
         return out.split(None)[-1]
 
     def submit_array(
@@ -478,15 +479,15 @@ import subprocess
 import sys
 
 task_id = os.environ['SLURM_ARRAY_TASK_ID']
-
-sys.exit(subprocess.call([a.replace(a, '%a', str(task_id)) for a in {args!r}])
+sys.exit(subprocess.call([a.replace('%a', str(task_id)) for a in {args!r}]))
 '''.format(python=sys.executable, args=args)
 
         cmd = self._prepare_submisson_cmd(
-            args, output_filename, name, scheduler_args, depends_on)
+            [], output_filename, name, scheduler_args, depends_on)
         p = subprocess.Popen(
             cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
-        out, _ = p.communicate(code)
+        out, _ = p.communicate(code.encode('utf-8'))
+        out = out.decode('utf-8')
         if p.returncode != 0:
             raise subprocess.CalledProcessError(p.returncode, cmd, out)
         return out.split(None)[-1]

--- a/psyrun/scheduler.py
+++ b/psyrun/scheduler.py
@@ -368,8 +368,6 @@ class Slurm(Scheduler):
 
     USER_DEFAULT_ARGS = {
         'timelimit': '1h',
-        'n_cpus': 1,
-        'n_nodes': 1,
         'memory': '1G',
     }
 

--- a/psyrun/scheduler.py
+++ b/psyrun/scheduler.py
@@ -396,9 +396,12 @@ class Slurm(Scheduler):
     KNOWN_ARGS = {
         'timelimit': _ShortOption('-t'),
         'output_file': _ShortOption('-o'),
+        'cores-per-socket': _LongOption('--cores-per-socket'),
+        'sockets-per-node': _LongOption('--sockets-per-node'),
         'n_cpus': _ShortOption('-c'),
         'n_nodes': _ShortOption('-N'),
-        'memory': _LongOption('--mem-per-cpu'),
+        'memory': _LongOption('--mem'),
+        'memory_per_cpu': _LongOption('--mem-per-cpu'),
         'depends_on': _ShortOption(
             '-d', lambda jobids: 'afterok:' + ':'.join(
                 str(x) for x in jobids)),

--- a/psyrun/scheduler.py
+++ b/psyrun/scheduler.py
@@ -268,6 +268,7 @@ class Sqsub(Scheduler):
         namedtuple or None
             Returns a tuple with *(id, status, name)* wherein status can be
 
+            - ``'R'`` for a running job
             - ``'Q'`` for a queued job
             - ``'*Q'`` for a queued job waiting on another job to finish
             - ``'Z'`` for a sleeping job
@@ -283,7 +284,7 @@ class Sqsub(Scheduler):
                 stdout = subprocess.check_output(
                     ['sqjobs', str(jobid)], stderr=subprocess.STDOUT,
                     universal_newlines=True)
-                for line in stdout.split(os.linesep)[2:]:
+                for line in stdout.split('\n')[2:]:
                     cols = line.split(None, 5)
                     if len(cols) > 3 and int(cols[0]) == jobid:
                         if cols[2] == 'C':
@@ -312,6 +313,6 @@ class Sqsub(Scheduler):
         stdout = subprocess.check_output(['sqjobs'], universal_newlines=True)
         for line in stdout.split('\n')[2:]:
             cols = line.split(None, 5)
-            if len(cols) > 2 and cols[2] in ['Q', '*Q', 'Z']:
+            if len(cols) > 2 and cols[2] in ['R', 'Q', '*Q', 'Z']:
                 jobid = int(cols[0])
                 self._jobs[jobid] = JobStatus(jobid, cols[2], cols[-1])

--- a/psyrun/scheduler.py
+++ b/psyrun/scheduler.py
@@ -495,7 +495,7 @@ sys.exit(subprocess.call([a.replace('%a', str(task_id)) for a in {args!r}]))
             'output_file': output_filename,
             'name': name,
         })
-        if len(depends_on) > 0:
+        if depends_on is not None and len(depends_on) > 0:
             scheduler_args['depends_on'] = depends_on
         return ['sbatch'] + self.build_args(**scheduler_args) + args
 
@@ -573,6 +573,6 @@ sys.exit(subprocess.call([a.replace('%a', str(task_id)) for a in {args!r}]))
                     for i in range(int(m.group(2)), int(m.group(3)) + 1):
                         sub_id = m.group(1) + '_' + str(i)
                         self._jobs[sub_id] = JobStatus(
-                            sub_id, status, cols[-1] + ':' + str(i))
+                            sub_id, status, cols[2] + ':' + str(i))
                 else:
-                    self._jobs[jobid] = JobStatus(jobid, status, cols[-1])
+                    self._jobs[jobid] = JobStatus(jobid, status, cols[2])

--- a/psyrun/scheduler.py
+++ b/psyrun/scheduler.py
@@ -48,7 +48,7 @@ class Scheduler(object):
         """Submit a job array.
 
         If the scheduler does not support job arrays, this method should raise
-        `NotImplementedError`.
+        *NotImplementedError*.
 
         Parameters
         ----------

--- a/psyrun/scheduler.py
+++ b/psyrun/scheduler.py
@@ -42,6 +42,38 @@ class Scheduler(object):
         """
         raise NotImplementedError()
 
+    def submit_array(
+            self, n, args, output_filename, name=None, depends_on=None,
+            scheduler_args=None):
+        """Submit a job array.
+
+        If the scheduler does not support job arrays, this method should raise
+        `NotImplementedError`.
+
+        Parameters
+        ----------
+        n : int
+            Number of tasks to submit.
+        args : sequence
+            The command and arguments to execute. The string ``'%a'`` will be
+            replaced with the task number in each argument.
+        output_filename : str
+            File to write process output to. The string ``'%a'`` will be
+            replaced by the task number.
+        name : str, optional
+            Name of job.
+        depends_on : sequence of int, optional
+            IDs of jobs that need to finish first before the submitted job can
+            be started.
+        scheduler_args : dict, optional
+            Additional arguments for the scheduler.
+
+        Returns
+        -------
+        Job ID
+        """
+        raise NotImplementedError()
+
     def kill(self, jobid):
         """Kill a job.
 
@@ -128,6 +160,11 @@ class ImmediateRun(Scheduler):
             if subprocess.call(args, stdout=f, stderr=subprocess.STDOUT) != 0:
                 self._failed_jobs.append(self._cur_id)
         return self._cur_id
+
+    def submit_array(
+            self, n, args, output_filename, name=None, depends_on=None,
+            scheduler_args=None):
+        raise NotImplementedError("Job arrays not supported.")
 
     def kill(self, jobid):
         """Has no effect."""
@@ -247,6 +284,11 @@ class Sqsub(Scheduler):
             ['sqsub'] + self.build_args(**scheduler_args) + args)
         with open(self.idfile, 'r') as f:
             return int(f.read())
+
+    def submit_array(
+            self, n, args, output_filename, name=None, depends_on=None,
+            scheduler_args=None):
+        raise NotImplementedError("Job arrays not supported.")
 
     def kill(self, jobid):
         """Kill a job.

--- a/psyrun/tasks.py
+++ b/psyrun/tasks.py
@@ -116,7 +116,7 @@ class Config(object):  # pylint: disable=too-many-instance-attributes
     """
 
     __slots__ = [
-        'backend', 'file_dep', 'max_jobs', 'min_items', 'pspace',
+        'backend', 'file_dep', 'max_jobs', 'min_items', 'pool_size', 'pspace',
         'overwrite_dirty', 'python', 'resultfile', 'scheduler',
         'scheduler_args', 'store', 'workdir']
 
@@ -126,6 +126,7 @@ class Config(object):  # pylint: disable=too-many-instance-attributes
         self.max_jobs = 100
         self.min_items = 1
         self.overwrite_dirty = True
+        self.pool_size = 1
         self.pspace = Param()
         self.python = sys.executable
         self.resultfile = None

--- a/psyrun/tests/test_main.py
+++ b/psyrun/tests/test_main.py
@@ -485,7 +485,7 @@ def test_psy_merge(tmpdir, store):
     psy_main(['merge', outdir, resultfile])
     merged = store.load(resultfile)
     assert list(merged.keys()) == ['x']
-    assert np.all(np.asarray(merged['x']) == np.array([1, 2]))
+    assert np.all(np.asarray(sorted(merged['x'])) == np.array([1, 2]))
 
 
 def test_new_task(taskenv):

--- a/psyrun/tests/test_scheduler.py
+++ b/psyrun/tests/test_scheduler.py
@@ -1,4 +1,7 @@
-from psyrun.scheduler import ImmediateRun
+import subprocess
+import sys
+
+from psyrun.scheduler import ImmediateRun, JobStatus, Slurm
 
 
 def test_immediate_run_submit(tmpdir):
@@ -17,3 +20,89 @@ def test_immediate_run_failing_job(tmpdir):
 
     with open(outfile, 'r') as f:
         assert f.read().strip() == ''
+
+
+def test_slurm_submit(monkeypatch, tmpdir):
+    def check_output(cmd, universal_newlines=None):
+        assert sorted(cmd) == sorted(
+            ['sbatch', '-o', 'outfile', '-J', 'name', '0', '1'])
+        return b'name 1'
+
+    monkeypatch.setattr(subprocess, 'check_output', check_output)
+
+    sched = Slurm(str(tmpdir))
+    assert sched.submit(['0', '1'], 'outfile', name='name') == '1'
+
+
+def test_slurm_submit_with_additional_args(monkeypatch, tmpdir):
+    def check_output(cmd, universal_newlines=None):
+        if cmd[0] == 'squeue':
+            return '\n0 R name None\n'
+        assert sorted(cmd) == sorted([
+            'sbatch', '-t', '1h', '-o', 'outfile', '-J', 'name', '-d',
+            'afterok:0', '0', '1'])
+        return b'name 1'
+
+    monkeypatch.setattr(subprocess, 'check_output', check_output)
+
+    sched = Slurm(str(tmpdir))
+    assert sched.submit(
+        ['0', '1'], 'outfile', name='name', depends_on=['0'],
+        scheduler_args={'timelimit': '1h'}) == '1'
+
+
+def test_slurm_kill(monkeypatch, tmpdir):
+    def check_call(cmd):
+        assert cmd == ['scancel', '1']
+
+    monkeypatch.setattr(subprocess, 'check_call', check_call)
+
+    sched = Slurm(str(tmpdir))
+    sched.kill('1')
+
+
+def test_slurm_status(monkeypatch, tmpdir):
+    def check_output(cmd, universal_newlines=None, stderr=None):
+        assert cmd[:2] == ['squeue', '-u']
+        assert cmd[3:5] == ['-h', '-o']
+        assert cmd[5] == '%i %t %j %r' or cmd[5] == '%A %t %j %r'
+        return '''id state name reason
+1 R running None
+2 PD pending Dependency
+3 PD priority Priority
+4_[0-2] PD array Priority
+'''
+
+    monkeypatch.setattr(subprocess, 'check_output', check_output)
+    sched = Slurm(str(tmpdir))
+    assert sorted(sched.get_jobs()) == ['1', '2', '3', '4_0', '4_1', '4_2']
+    assert sched.get_status('1') == JobStatus('1', 'R', 'running')
+    assert sched.get_status('2') == JobStatus('2', '*Q', 'pending')
+    assert sched.get_status('3') == JobStatus('3', 'Q', 'priority')
+    for i in range(3):
+        job_id = '4_' + str(i)
+        assert sched.get_status(job_id) == JobStatus(
+            job_id, 'Q', 'array:' + str(i))
+
+
+def test_slurm_submit_array(monkeypatch, tmpdir):
+    class Popen(object):
+        def __init__(self, cmd, stdin=None, stdout=None):
+            assert sorted(cmd) == sorted(
+                ['sbatch', '--array=0-2', '-o', 'outfile'])
+            self.returncode = 0
+
+        def communicate(self, input):
+            assert input.decode('utf-8') == '#!' + sys.executable + '''
+import os
+import subprocess
+import sys
+
+task_id = os.environ['SLURM_ARRAY_TASK_ID']
+sys.exit(subprocess.call([a.replace('%a', str(task_id)) for a in ['arg0', 'arg1']]))
+'''
+            return b'array 1', b''
+
+    monkeypatch.setattr(subprocess, 'Popen', Popen)
+    sched = Slurm(str(tmpdir))
+    sched.submit_array(3, ['arg0', 'arg1'], 'outfile')


### PR DESCRIPTION
Slurm is used on the new graham.computecanada.ca and cedar.computecanada.ca clusters.

Todo:
- [x] Submit processing jobs as a single job with multiple tasks to speed up job submission. (distribute backend)
- [x] Submit processing jobs as a single job with multiple tasks to speed up job submission. (load balancing backend)
- [x] Allocating full nodes can give better scheduling. Thus it might be good to introduce parallelism in the process jobs.
- [x] Parse `squeue` reason column to figure out when a job is still queued due to a dependency.
- [x] Reduce code duplication between Sqsub and Slurm scheduler.
- [x] Is there some way to test some of that code to improve code coverage?
- [x] Changelog entry.
- [x] Update documentation.
